### PR TITLE
Added support for additional args for refreshdata. Closes #1

### DIFF
--- a/api/management/commands/refreshdata.py
+++ b/api/management/commands/refreshdata.py
@@ -131,12 +131,26 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         """
-        For now we just overwrite all entries in the db.
+        It is possible to choose which entry we want to overwrite. If
+        no args are given all entries will be overwritten
         """
-        self.process_commodities()
-        self.process_systems()
-        self.process_stations()
-        self.process_listings()
+        if len(args) == 0:
+            self.process_commodities()
+            self.process_systems()
+            self.process_stations()
+            self.process_listings()
+            return
+
+        refresh_types = {"commodities": self.process_commodities,
+                         "systems": self.process_systems,
+                         "stations": self.process_stations,
+                         "listings": self.process_listings
+                         }
+        for arg in args:
+            try:
+                refresh_types[arg]()
+            except KeyError:
+                logger.debug("No such option.")
 
     @staticmethod
     def _fetch_json(url) -> list:


### PR DESCRIPTION
Finished issue #1. refreshdata supports additional arguments (such sa listing, commodities, systems or stations).
